### PR TITLE
Enable gateway-based auth

### DIFF
--- a/frontend/constants.js
+++ b/frontend/constants.js
@@ -1,2 +1,2 @@
-export const ACCESS_TOKEN = 'access';
-export const REFRESH_TOKEN = 'refresh';
+export const ACCESS_TOKEN = 'access_token';
+export const REFRESH_TOKEN = 'refresh_token';

--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -1,9 +1,9 @@
 import axios from 'axios';
-import { ACCESS_TOKEN } from './constants';
+import { ACCESS_TOKEN } from '../../constants';
 
 const api = axios.create({
-    baseURL: import.meta.env.GATEWAY_URL,
-})
+    baseURL: import.meta.env.VITE_GATEWAY_URL || 'http://host.minikube.internal:3000',
+});
 
 api.interceptors.request.use(
     (config) => {
@@ -16,7 +16,6 @@ api.interceptors.request.use(
     (error) => {
         return Promise.reject(error);
     }
-)
+);
 
 export default api;
-// Compare this snippet from Auth/frontend/src/constants.js:

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,12 +1,13 @@
 import axios from 'axios';
 
 const authApi = axios.create({
-    baseURL: import.meta.env.VITE_AUTH_URL || 'http://auth-api:8002/api/v1/auth',
+    baseURL: import.meta.env.VITE_GATEWAY_URL || 'http://host.minikube.internal:3000',
     headers: { 'Content-Type': 'application/json' },
 });
 
 export const register = (data) => authApi.post('/register', data);
-export const login = (data) => authApi.post('/login', data);
+export const login = (email, password) =>
+    authApi.post('/login', {}, { auth: { username: email, password } });
 export const oauthLogin = (provider) => {
     window.location.href = `${authApi.defaults.baseURL}/${provider}/login`;
 };

--- a/frontend/src/api/crypta.js
+++ b/frontend/src/api/crypta.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const apiClient = axios.create({
-    baseURL: import.meta.env.VITE_API_URL,
+    baseURL: import.meta.env.VITE_GATEWAY_URL || 'http://host.minikube.internal:3000',
     headers: { 'Content-Type': 'application/json' },
 });
 

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
-import '../styles/Login.css'
+import '../styles/Login.css';
 import Card from '../components/Card';
 import logo from '../assets/images/logo.png';
 import { login } from '../api/auth';
+import { ACCESS_TOKEN } from '../../constants';
 
 const Login = () => {
   const [email, setEmail] = useState('');
@@ -11,7 +12,7 @@ const Login = () => {
   const [error, setError] = useState(null);
 
   const handleEmailSubmit = (e) => {
-    e.preventDefault()
+    e.preventDefault();
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (emailRegex.test(email)) {
       setError(null);
@@ -24,20 +25,20 @@ const Login = () => {
   const handleLogin = async (e) => {
     e.preventDefault();
     try {
-      const { data } = await login({ email, password });
-      localStorage.setItem('token', data.access_token);
+      const { data } = await login(email, password);
+      localStorage.setItem(ACCESS_TOKEN, data);
       window.location.href = '/';
-    } catch (err) {
+    } catch {
       setError('Invalid Credentials');
     }
   };
 
-return (
-  <div className="d-flex justify-content-center align-items-center vh-100 login-background">
-    <Card className="login-card text-center rounded-4 shadow p-4">
-      <img src={logo} alt="Company Logo" className="login-logo mb-4" />
-      <h4 className="mb-4">Sign in to Your Account</h4>
-      <form onSubmit={step === 1 ? handleEmailSubmit : handleLogin} className="text-start">
+  return (
+    <div className="d-flex justify-content-center align-items-center vh-100 login-background">
+      <Card className="login-card text-center rounded-4 shadow p-4">
+        <img src={logo} alt="Company Logo" className="login-logo mb-4" />
+        <h4 className="mb-4">Sign in to Your Account</h4>
+        <form onSubmit={step === 1 ? handleEmailSubmit : handleLogin} className="text-start">
           <div className="mb-4">
             <label htmlFor="email" className="form-label">Email</label>
             <input
@@ -45,48 +46,45 @@ return (
               className="form-control"
               id="email"
               value={email}
-              onChange={(e) => {
-                setEmail(e.target.value);
-              }
-              }
+              onChange={(e) => setEmail(e.target.value)}
               required
-              />
+            />
           </div>
-        {step === 2 && (
-          <>
-            <div className="mb-4">
-              <label htmlFor="password" className="form-label">Password</label>
-              <input
-                type="password"
-                className="form-control"
-                id="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
+          {step === 2 && (
+            <>
+              <div className="mb-4">
+                <label htmlFor="password" className="form-label">Password</label>
+                <input
+                  type="password"
+                  className="form-control"
+                  id="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
                 />
-            </div>
-            {error && <div className="text-danger mb-2">{error}</div>}
-          </>
-        )}
-        <button type="submit" className="btn btn-primary w-100 btn-login mb-3">
-          {step === 1 ? "Next" : "Sign In"}
-        </button>
-        {step === 2 && (
-          <button type="button" className="btn btn-link w-100 mb-3" onClick={() => setStep(1)}>
-            Back
+              </div>
+              {error && <div className="text-danger mb-2">{error}</div>}
+            </>
+          )}
+          <button type="submit" className="btn btn-primary w-100 btn-login mb-3">
+            {step === 1 ? 'Next' : 'Sign In'}
           </button>
-        )}
-        <button
-          type="button"
-          className="btn btn-primary w-100 btn-login mb-3"
-          onClick={() => {
-            localStorage.clear();
-            window.location.href = '/register';
-          }}
+          {step === 2 && (
+            <button type="button" className="btn btn-link w-100 mb-3" onClick={() => setStep(1)}>
+              Back
+            </button>
+          )}
+          <button
+            type="button"
+            className="btn btn-primary w-100 btn-login mb-3"
+            onClick={() => {
+              localStorage.clear();
+              window.location.href = '/register';
+            }}
           >
             Register
-            </button>
-          </form>
+          </button>
+        </form>
         <small className="text-muted d-block mt-4">Need help? Contact <a href="mailto:helpdesk@rcdoc.org">helpdesk@rcdoc.org</a></small>
       </Card>
     </div>

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import '../styles/Login.css'
+import '../styles/Login.css';
 import Card from '../components/Card';
 import logo from '../assets/images/logo.png';
 import { register, oauthLogin } from '../api/auth';
@@ -19,56 +19,56 @@ const Register = () => {
     try {
       await register({ email, password });
       window.location.href = '/login';
-    } catch (err) {
+    } catch {
       setError('Unable to register');
     }
   };
 
   return (
     <div className="d-flex justify-content-center align-items-center vh-100 login-background">
-    <Card className="login-card text-center rounded-4 shadow p-4">
-      <img src={logo} alt="Company Logo" className="login-logo mb-4" />
-      <h4 className="mb-4">Register</h4>
-      <form method="post" onSubmit={handleSubmit} className="text-start">
-        <div className="mb-3">
-          <label htmlFor="email" className="form-label">Email</label>
-          <input 
-            type="email"
-            className="form-control"
-            id="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-          />
-        </div>
-        <div className="mb-4">
-          <label htmlFor="password" className="form-label">Password</label>
-          <input 
-            type="password" 
-            className="form-control" 
-            id="password" 
-            placeholder="Enter your password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required 
-          />
-        </div>
-        <div className="mb-4">
-          <label htmlFor="confirm" className="form-label">Confirm Password</label>
-          <input 
-            type="password" 
-            className="form-control" 
-            id="confirm" 
-            placeholder="Enter your password"
-            value={confirm}
-            onChange={(e) => setConfirm(e.target.value)}
-            required 
-          />
-        </div>
-        {error && <div className="text-danger mb-2">{error}</div>}
-        <button type="submit" className="btn btn-primary w-100 btn-login mb-3">Register</button>
-        <div className="text-center my-3">—or sign up with—</div>
-        <button type="button" className="btn btn-light w-100 mb-2 oauth-btn oauth-google" onClick={() => oauthLogin('google')}>
+      <Card className="login-card text-center rounded-4 shadow p-4">
+        <img src={logo} alt="Company Logo" className="login-logo mb-4" />
+        <h4 className="mb-4">Register</h4>
+        <form method="post" onSubmit={handleSubmit} className="text-start">
+          <div className="mb-3">
+            <label htmlFor="email" className="form-label">Email</label>
+            <input
+              type="email"
+              className="form-control"
+              id="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div className="mb-4">
+            <label htmlFor="password" className="form-label">Password</label>
+            <input
+              type="password"
+              className="form-control"
+              id="password"
+              placeholder="Enter your password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+          <div className="mb-4">
+            <label htmlFor="confirm" className="form-label">Confirm Password</label>
+            <input
+              type="password"
+              className="form-control"
+              id="confirm"
+              placeholder="Enter your password"
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              required
+            />
+          </div>
+          {error && <div className="text-danger mb-2">{error}</div>}
+          <button type="submit" className="btn btn-primary w-100 btn-login mb-3">Register</button>
+          <div className="text-center my-3">—or sign up with—</div>
+          <button type="button" className="btn btn-light w-100 mb-2 oauth-btn oauth-google" onClick={() => oauthLogin('google')}>
             <img src="/assets/images/google-logo.png" alt="Google Logo" className="oauth-logo me-2" />Google
           </button>
           <button type="button" className="btn btn-light w-100 oauth-btn oauth-microsoft" onClick={() => oauthLogin('microsoft')}>
@@ -81,11 +81,11 @@ const Register = () => {
           >
             Sign In
           </button>
-      </form>
-      <small className="text-muted d-block mt-4">Need help? Contact <a href="mailto:helpdesk@rcdoc.org">helpdesk@rcdoc.org</a></small>
-    </Card>
-  </div>
-  )
+        </form>
+        <small className="text-muted d-block mt-4">Need help? Contact <a href="mailto:helpdesk@rcdoc.org">helpdesk@rcdoc.org</a></small>
+      </Card>
+    </div>
+  );
 };
 
 export default Register;

--- a/services/auth/server.py
+++ b/services/auth/server.py
@@ -41,6 +41,18 @@ def login():
         return "bad credentials", 401
     return createJWT(auth.username, JWT_SECRET, user.roles, user.admin)
 
+@server.route("/api/v1/auth/register", methods=["POST"])
+def register():
+    data = request.get_json()
+    if not data or not data.get("email") or not data.get("password"):
+        return "missing credentials", 400
+    if User.objects(email=data["email"]).first():
+        return "user exists", 409
+    user = User(email=data["email"])
+    user.set_password(data["password"])
+    user.save()
+    return "", 201
+
 @server.route("/api/v1/auth/validate", methods=["POST"])
 def validate():
     encoded_jwt = request.headers["Authorization"]

--- a/services/gateway/auth_svc/access.py
+++ b/services/gateway/auth_svc/access.py
@@ -1,18 +1,27 @@
-import os, requests
+import os
+import requests
+
+AUTH_ADDR = os.environ.get('AUTH_SVC_ADDRESS')
 
 def login(request):
     auth = request.authorization
     if not auth:
         return None, ("missing credentials", 401)
-    
-    basicAuth = (auth.username, auth.password)
-    
+
     response = requests.post(
-        f"http://{os.environ.get('AUTH_SVC_ADDRESS')}/api/v1/auth/login",
-        auth=basicAuth
+        f"http://{AUTH_ADDR}/api/v1/auth/login",
+        auth=(auth.username, auth.password),
     )
-    
     if response.status_code == 200:
         return response.text, None
-    else:
-        return None, (response.text, response.status_code)
+    return None, (response.text, response.status_code)
+
+def register(request):
+    data = request.get_json()
+    response = requests.post(
+        f"http://{AUTH_ADDR}/api/v1/auth/register",
+        json=data,
+    )
+    if response.status_code in (200, 201):
+        return response.text, None
+    return None, (response.text, response.status_code)

--- a/services/gateway/server.py
+++ b/services/gateway/server.py
@@ -17,6 +17,14 @@ def login():
         return token
     else:
         return err
+
+@server.route("/register", methods=["POST"])
+def register():
+    resp, err = access.register(request)
+    if not err:
+        return resp
+    else:
+        return err
     
 @server.route("/validate", methods=["POST"])
 def validate():


### PR DESCRIPTION
## Summary
- wire up generic API helper to use gateway URL
- send login/register requests through gateway
- adjust login/register pages to save tokens correctly
- add register endpoint to auth service
- expose register route in gateway
- default all service URLs to gateway

## Testing
- `python -m py_compile services/auth/server.py services/gateway/server.py services/gateway/auth_svc/access.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852f5a61390832aa28bc1c6f829938c