### PR TITLE
Fix gateway URL defaults

### DIFF
--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -2,7 +2,12 @@ import axios from 'axios';
 import { ACCESS_TOKEN } from '../../constants';
 
 const api = axios.create({
-    baseURL: import.meta.env.VITE_GATEWAY_URL || 'http://host.minikube.internal:3000',
+    // Use the API gateway URL from the environment when provided. Default to
+    // localhost so the frontend works during local development without
+    // Kubernetes/minikube.
+    baseURL:
+        import.meta.env.VITE_GATEWAY_URL ||
+        'http://localhost:3000',
 });
 
 api.interceptors.request.use(

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,7 +1,12 @@
 import axios from 'axios';
 
 const authApi = axios.create({
-    baseURL: import.meta.env.VITE_GATEWAY_URL || 'http://host.minikube.internal:3000',
+    // Allow overriding the API gateway URL via environment variable. Fall back
+    // to localhost when running the services locally so that registration and
+    // login work without a Kubernetes setup.
+    baseURL:
+        import.meta.env.VITE_GATEWAY_URL ||
+        'http://localhost:3000',
     headers: { 'Content-Type': 'application/json' },
 });
 

--- a/frontend/src/api/crypta.js
+++ b/frontend/src/api/crypta.js
@@ -1,7 +1,11 @@
 import axios from 'axios';
 
 const apiClient = axios.create({
-    baseURL: import.meta.env.VITE_GATEWAY_URL || 'http://host.minikube.internal:3000',
+    // Allow the gateway URL to be configured via environment variable. Fall
+    // back to localhost for local development environments.
+    baseURL:
+        import.meta.env.VITE_GATEWAY_URL ||
+        'http://localhost:3000',
     headers: { 'Content-Type': 'application/json' },
 });
 


### PR DESCRIPTION
## Summary
- make frontend default to localhost instead of `host.minikube.internal`

## Testing
- `npm run lint` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_6855573e1a18832ab26418de2549317f