### PR TITLE
Fix gateway CORS and dynamic URL

### DIFF
--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -1,13 +1,15 @@
 import axios from 'axios';
 import { ACCESS_TOKEN } from '../../constants';
 
+// Compute the gateway URL based on the current page host so the frontend works
+// when accessed remotely.  This can be overridden with the VITE_GATEWAY_URL
+// environment variable for special cases.
+const gatewayUrl =
+    import.meta.env.VITE_GATEWAY_URL ||
+    `${window.location.protocol}//${window.location.hostname}:3000`;
+
 const api = axios.create({
-    // Use the API gateway URL from the environment when provided. Default to
-    // localhost so the frontend works during local development without
-    // Kubernetes/minikube.
-    baseURL:
-        import.meta.env.VITE_GATEWAY_URL ||
-        'http://localhost:3000',
+    baseURL: gatewayUrl,
 });
 
 api.interceptors.request.use(

--- a/frontend/src/api/auth.js
+++ b/frontend/src/api/auth.js
@@ -1,12 +1,14 @@
 import axios from 'axios';
 
+// Derive the gateway URL dynamically so the frontend works whether it is served
+// locally or from another host.  An environment variable can still override
+// this when needed.
+const gatewayUrl =
+    import.meta.env.VITE_GATEWAY_URL ||
+    `${window.location.protocol}//${window.location.hostname}:3000`;
+
 const authApi = axios.create({
-    // Allow overriding the API gateway URL via environment variable. Fall back
-    // to localhost when running the services locally so that registration and
-    // login work without a Kubernetes setup.
-    baseURL:
-        import.meta.env.VITE_GATEWAY_URL ||
-        'http://localhost:3000',
+    baseURL: gatewayUrl,
     headers: { 'Content-Type': 'application/json' },
 });
 

--- a/frontend/src/api/crypta.js
+++ b/frontend/src/api/crypta.js
@@ -1,11 +1,14 @@
 import axios from 'axios';
 
+// Determine the gateway URL from the current host, falling back to an
+// environment variable if provided.  This keeps API calls working when the UI
+// is accessed via a remote IP.
+const gatewayUrl =
+    import.meta.env.VITE_GATEWAY_URL ||
+    `${window.location.protocol}//${window.location.hostname}:3000`;
+
 const apiClient = axios.create({
-    // Allow the gateway URL to be configured via environment variable. Fall
-    // back to localhost for local development environments.
-    baseURL:
-        import.meta.env.VITE_GATEWAY_URL ||
-        'http://localhost:3000',
+    baseURL: gatewayUrl,
     headers: { 'Content-Type': 'application/json' },
 });
 

--- a/services/gateway/requirements.txt
+++ b/services/gateway/requirements.txt
@@ -15,3 +15,4 @@ urllib3==2.5.0
 Werkzeug==3.1.3
 gunicorn==21.2.0
 uvicorn>=0.22,<1.0
+Flask-CORS==6.0.1

--- a/services/gateway/server.py
+++ b/services/gateway/server.py
@@ -1,11 +1,19 @@
-import os, json
+import os
+import json
 from flask import Flask, request
 from flask_pymongo import PyMongo
+from flask_cors import CORS
 from auth import validate
 from auth_svc import access
 
 server = Flask(__name__)
 server.config["MONGO_URI"] = "mongodb://host.minikube.internal:27017/docs"
+
+# Enable Cross-Origin Resource Sharing so the frontend can call the gateway from
+# different origins (e.g. when the UI is served from a separate container or
+# host).  "supports_credentials" allows cookies/authorization headers to be
+# passed through when present.
+CORS(server, supports_credentials=True)
 
 mongo = PyMongo(server)
 


### PR DESCRIPTION
## Summary
- enable CORS in the gateway service
- dynamically build gateway URL in frontend API helpers
- add flask-cors dependency

## Testing
- `python -m py_compile services/gateway/server.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68555b04bb3c832a92ca2e929db7ad72