### PR TITLE
Add gateway MFA forwarding

### DIFF
--- a/services/gateway/api/tests/test_views.py
+++ b/services/gateway/api/tests/test_views.py
@@ -7,6 +7,9 @@ from rest_framework.test import APITestCase
 REGISTER_URL = os.getenv('AUTH_REGISTER_URL', 'http://localhost:8002/api/v1/user/register/')
 LOGIN_URL = os.getenv('AUTH_LOGIN_URL', 'http://localhost:8002/api/v1/token/')
 REFRESH_URL = os.getenv('AUTH_REFRESH_URL', 'http://localhost:8002/api/v1/token/refresh/')
+MFA_ENABLE_URL = os.getenv('AUTH_MFA_ENABLE_URL', 'http://localhost:8002/api/v1/mfa/enable/')
+MFA_VERIFY_URL = os.getenv('AUTH_MFA_VERIFY_URL', 'http://localhost:8002/api/v1/mfa/verify/')
+MFA_DISABLE_URL = os.getenv('AUTH_MFA_DISABLE_URL', 'http://localhost:8002/api/v1/mfa/disable/')
 
 class RegisterViewTests(APITestCase):
     """Used for testing registration of users."""
@@ -84,3 +87,60 @@ class TokenRefreshViewTests(APITestCase):
         self.assertEqual(args[0], REFRESH_URL)
         flat_data = kwargs['json']
         self.assertEqual(flat_data, data)
+
+
+class EnableMFAViewTests(APITestCase):
+    @patch('api.views.requests.post')
+    def test_enable_route_calls_auth_service(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {'Content-Type': 'application/json'}
+        mock_response.json.return_value = {'secret': 'abc'}
+        mock_post.return_value = mock_response
+
+        url = reverse('mfa-enable')
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 200)
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        self.assertEqual(args[0], MFA_ENABLE_URL)
+
+
+class VerifyMFAViewTests(APITestCase):
+    @patch('api.views.requests.post')
+    def test_verify_route_calls_auth_service(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {'Content-Type': 'application/json'}
+        mock_response.json.return_value = {'detail': 'MFA enabled'}
+        mock_post.return_value = mock_response
+
+        data = {'otp': '123456'}
+        url = reverse('mfa-verify')
+        response = self.client.post(url, data)
+
+        self.assertEqual(response.status_code, 200)
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        self.assertEqual(args[0], MFA_VERIFY_URL)
+        flat_data = kwargs['json']
+        self.assertEqual(flat_data, data)
+
+
+class DisableMFAViewTests(APITestCase):
+    @patch('api.views.requests.post')
+    def test_disable_route_calls_auth_service(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {'Content-Type': 'application/json'}
+        mock_response.json.return_value = {'detail': 'MFA disabled'}
+        mock_post.return_value = mock_response
+
+        url = reverse('mfa-disable')
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, 200)
+        mock_post.assert_called_once()
+        args, kwargs = mock_post.call_args
+        self.assertEqual(args[0], MFA_DISABLE_URL)

--- a/services/gateway/api/views.py
+++ b/services/gateway/api/views.py
@@ -17,6 +17,9 @@ AUTH_ORGS_URL = os.getenv('AUTH_ORGS_URL', 'http://localhost:8002/api/v1/organiz
 AUTH_ATTEMPTS_URL = os.getenv('AUTH_ATTEMPTS_URL', 'http://localhost:8002/api/v1/login_attempts/')
 AUTH_GROUPS_URL = os.getenv('AUTH_GROUPS_URL', 'http://localhost:8002/api/v1/crypta_groups/')
 AUTH_PERMS_URL = os.getenv('AUTH_PERMS_URL', 'http://localhost:8002/api/v1/query_permissions/')
+AUTH_MFA_ENABLE_URL = os.getenv('AUTH_MFA_ENABLE_URL', 'http://localhost:8002/api/v1/mfa/enable/')
+AUTH_MFA_VERIFY_URL = os.getenv('AUTH_MFA_VERIFY_URL', 'http://localhost:8002/api/v1/mfa/verify/')
+AUTH_MFA_DISABLE_URL = os.getenv('AUTH_MFA_DISABLE_URL', 'http://localhost:8002/api/v1/mfa/disable/')
 
 # Create your views here.
 class CreateUserView_v1(APIView):
@@ -310,6 +313,54 @@ class QueryPermissionDetailView_v1(APIView):
             resp = requests.post(f'{AUTH_PERMS_URL}create/', json=request.data)
             logger.info('Auth Service returned status %s', resp.status_code)
             data = resp.json() if resp.text else ''
+            return Response(data, status=resp.status_code)
+        except requests.RequestException as exc:
+            logger.error('Failed to contact auth service: %s', exc, exc_info=True)
+            return Response({'detail': 'Authentication service unavailable'}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+
+
+class EnableMFAView_v1(APIView):
+    permission_classes = [permissions.AllowAny]
+
+    def post(self, request, *args, **kwargs):
+        logger.debug('Forwarding enable MFA request')
+        try:
+            resp = requests.post(AUTH_MFA_ENABLE_URL, json=request.data)
+            logger.info('Auth Service returned status %s', resp.status_code)
+            content_type = resp.headers.get('Content-Type', '')
+            data = resp.json() if content_type.startswith('application/json') else resp.text
+            return Response(data, status=resp.status_code)
+        except requests.RequestException as exc:
+            logger.error('Failed to contact auth service: %s', exc, exc_info=True)
+            return Response({'detail': 'Authentication service unavailable'}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+
+
+class VerifyMFAView_v1(APIView):
+    permission_classes = [permissions.AllowAny]
+
+    def post(self, request, *args, **kwargs):
+        logger.debug('Forwarding verify MFA request')
+        try:
+            resp = requests.post(AUTH_MFA_VERIFY_URL, json=request.data)
+            logger.info('Auth Service returned status %s', resp.status_code)
+            content_type = resp.headers.get('Content-Type', '')
+            data = resp.json() if content_type.startswith('application/json') else resp.text
+            return Response(data, status=resp.status_code)
+        except requests.RequestException as exc:
+            logger.error('Failed to contact auth service: %s', exc, exc_info=True)
+            return Response({'detail': 'Authentication service unavailable'}, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+
+
+class DisableMFAView_v1(APIView):
+    permission_classes = [permissions.AllowAny]
+
+    def post(self, request, *args, **kwargs):
+        logger.debug('Forwarding disable MFA request')
+        try:
+            resp = requests.post(AUTH_MFA_DISABLE_URL, json=request.data)
+            logger.info('Auth Service returned status %s', resp.status_code)
+            content_type = resp.headers.get('Content-Type', '')
+            data = resp.json() if content_type.startswith('application/json') else resp.text
             return Response(data, status=resp.status_code)
         except requests.RequestException as exc:
             logger.error('Failed to contact auth service: %s', exc, exc_info=True)

--- a/services/gateway/gateway/urls.py
+++ b/services/gateway/gateway/urls.py
@@ -31,6 +31,9 @@ from api.views import (
     CryptaGroupDetailView_v1,
     QueryPermissionsView_v1,
     QueryPermissionDetailView_v1,
+    EnableMFAView_v1,
+    VerifyMFAView_v1,
+    DisableMFAView_v1,
 )
 
 urlpatterns = [
@@ -55,5 +58,8 @@ urlpatterns = [
     path('api/v1/users/register/', CreateUserView_v1.as_view(), name='register'),
     path('users/login/', LoginView_v1.as_view(), name='login'),
     path('api/v1/tokens/retrieve/', LoginView_v1.as_view(), name='get_token'),
-    path('tokens/refresh/', TokenRefreshView_v1.as_view(), name='token_refresh')
+    path('tokens/refresh/', TokenRefreshView_v1.as_view(), name='token_refresh'),
+    path('mfa/enable/', EnableMFAView_v1.as_view(), name='mfa-enable'),
+    path('mfa/verify/', VerifyMFAView_v1.as_view(), name='mfa-verify'),
+    path('mfa/disable/', DisableMFAView_v1.as_view(), name='mfa-disable')
 ]


### PR DESCRIPTION
## Summary
- add MFA URL environment variables for gateway service
- proxy MFA routes from gateway to auth service
- expose MFA endpoints via Django urlconf
- test MFA gateway views

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68630c35b418832aa90c14b77a8993cc