### PR TITLE
Add logging and tests for auth & gateway services

### DIFF
--- a/services/auth/api/tests/__init__.py
+++ b/services/auth/api/tests/__init__.py
@@ -1,2 +1,1 @@
-from . import test_models
-from . import test_views
+"""Test package for auth service."""

--- a/services/auth/api/tests/test_views.py
+++ b/services/auth/api/tests/test_views.py
@@ -1,1 +1,80 @@
-from django.test import TestCase
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+import pyotp
+
+from api.models import Role, Organization, CryptaGroup, QueryPermission, User, UserProfile
+
+class DetailViewTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="tester", email="t@e.com", password="pass")
+        UserProfile.objects.create(user=self.user, name_first="", name_last="", mfa_secret_hash=pyotp.random_base32())
+        self.role = Role.objects.create(name="role")
+        self.org = Organization.objects.create(name="org", ref_location_id=1)
+        self.group = CryptaGroup.objects.create(name="group", description="d")
+        self.permission = QueryPermission.objects.create(
+            group=self.group,
+            resource_type=QueryPermission.ResourceType.PERSON,
+            access_type=QueryPermission.AccessType.READ,
+            view_limits={},
+            filter_conditions={},
+        )
+
+    def test_role_detail_get_delete(self):
+        url = reverse("role-detail", args=[self.role.pk])
+        self.client.force_authenticate(self.user)
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        resp = self.client.delete(url)
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_org_detail_get_delete(self):
+        url = reverse("organization-detail", args=[self.org.pk])
+        self.client.force_authenticate(self.user)
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        resp = self.client.delete(url)
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_group_detail_get_delete(self):
+        url = reverse("crypta-group-detail", args=[self.group.pk])
+        self.client.force_authenticate(self.user)
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        resp = self.client.delete(url)
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_permission_detail_get_delete(self):
+        url = reverse("query-permission-detail", args=[self.permission.pk])
+        self.client.force_authenticate(self.user)
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        resp = self.client.delete(url)
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_user_detail_get_delete(self):
+        url = reverse("user-detail", args=[self.user.pk])
+        self.client.force_authenticate(self.user)
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        resp = self.client.delete(url)
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+
+class VerifyMfaViewTests(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="tester", email="t@e.com", password="pass")
+        secret = pyotp.random_base32()
+        self.profile = UserProfile.objects.create(
+            user=self.user,
+            name_first="",
+            name_last="",
+            mfa_secret_hash=secret,
+        )
+
+    def test_verify_mfa(self):
+        totp = pyotp.TOTP(self.profile.mfa_secret_hash)
+        url = reverse("verify-mfa")
+        data = {"user_id": self.user.id, "otp": totp.now()}
+        resp = self.client.post(url, data)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+

--- a/services/gateway/api/tests/__init__.py
+++ b/services/gateway/api/tests/__init__.py
@@ -1,2 +1,1 @@
-from . import test_models
-from . import test_views
+"""Test package for gateway service."""

--- a/services/gateway/api/tests/test_views.py
+++ b/services/gateway/api/tests/test_views.py
@@ -108,3 +108,223 @@ class VerifyMfaViewTests(APITestCase):
         self.assertEqual(args[0], VERIFY_URL)
         flat_data = kwargs['json']
         self.assertEqual(flat_data, data)
+
+class UsersViewTests(APITestCase):
+    @patch('api.views.requests.get')
+    def test_users_list_calls_auth_service(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        url = reverse('users')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        mock_get.assert_called_once()
+
+    @patch('api.views.requests.delete')
+    def test_users_delete_calls_auth_service(self, mock_delete):
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_response.json.return_value = {}
+        mock_delete.return_value = mock_response
+
+        url = reverse('user-detail', args=[1])
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, 204)
+        mock_delete.assert_called_once()
+
+class RolesViewTests(APITestCase):
+    @patch('api.views.requests.get')
+    def test_roles_list_calls_auth_service(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        url = reverse('roles')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        mock_get.assert_called_once()
+
+class RoleDetailViewTests(APITestCase):
+    @patch('api.views.requests.delete')
+    def test_role_delete_calls_auth_service(self, mock_delete):
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_response.json.return_value = {}
+        mock_delete.return_value = mock_response
+
+        url = reverse('role-detail', args=[1])
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, 204)
+        mock_delete.assert_called_once()
+
+    @patch('api.views.requests.post')
+    def test_role_create_calls_auth_service(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.json.return_value = {}
+        mock_post.return_value = mock_response
+
+        url = reverse('roles')
+        response = self.client.post(url, {'name': 'r'})
+
+        self.assertEqual(response.status_code, 201)
+        mock_post.assert_called_once()
+
+class TokensViewTests(APITestCase):
+    @patch('api.views.requests.get')
+    def test_tokens_list_calls_auth_service(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        url = reverse('tokens')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        mock_get.assert_called_once()
+
+class OrganizationsViewTests(APITestCase):
+    @patch('api.views.requests.get')
+    def test_orgs_list_calls_auth_service(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        url = reverse('organizations')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        mock_get.assert_called_once()
+
+class OrganizationDetailViewTests(APITestCase):
+    @patch('api.views.requests.delete')
+    def test_org_delete_calls_auth_service(self, mock_delete):
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_response.json.return_value = {}
+        mock_delete.return_value = mock_response
+
+        url = reverse('organization-detail', args=[1])
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, 204)
+        mock_delete.assert_called_once()
+
+    @patch('api.views.requests.post')
+    def test_org_create_calls_auth_service(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.json.return_value = {}
+        mock_post.return_value = mock_response
+
+        url = reverse('organization-detail')
+        response = self.client.post(url, {'name': 'o'})
+
+        self.assertEqual(response.status_code, 201)
+        mock_post.assert_called_once()
+
+class LoginAttemptsViewTests(APITestCase):
+    @patch('api.views.requests.get')
+    def test_attempts_list_calls_auth_service(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        url = reverse('login_attempts')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        mock_get.assert_called_once()
+
+class CryptaGroupsViewTests(APITestCase):
+    @patch('api.views.requests.get')
+    def test_groups_list_calls_auth_service(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        url = reverse('crypta_groups')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        mock_get.assert_called_once()
+
+class CryptaGroupDetailViewTests(APITestCase):
+    @patch('api.views.requests.delete')
+    def test_group_delete_calls_auth_service(self, mock_delete):
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_response.json.return_value = {}
+        mock_delete.return_value = mock_response
+
+        url = reverse('crypta_group-detail', args=[1])
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, 204)
+        mock_delete.assert_called_once()
+
+    @patch('api.views.requests.post')
+    def test_group_create_calls_auth_service(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.json.return_value = {}
+        mock_post.return_value = mock_response
+
+        url = reverse('crypta_group-detail')
+        response = self.client.post(url, {'name': 'g'})
+
+        self.assertEqual(response.status_code, 201)
+        mock_post.assert_called_once()
+
+class QueryPermissionsViewTests(APITestCase):
+    @patch('api.views.requests.get')
+    def test_perms_list_calls_auth_service(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = []
+        mock_get.return_value = mock_response
+
+        url = reverse('query_permissions')
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        mock_get.assert_called_once()
+
+class QueryPermissionDetailViewTests(APITestCase):
+    @patch('api.views.requests.delete')
+    def test_perm_delete_calls_auth_service(self, mock_delete):
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_response.json.return_value = {}
+        mock_delete.return_value = mock_response
+
+        url = reverse('query_permission-detail', args=[1])
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, 204)
+        mock_delete.assert_called_once()
+
+    @patch('api.views.requests.post')
+    def test_perm_create_calls_auth_service(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.status_code = 201
+        mock_response.json.return_value = {}
+        mock_post.return_value = mock_response
+
+        url = reverse('query_permission-detail')
+        response = self.client.post(url, {'name': 'p'})
+
+        self.assertEqual(response.status_code, 201)
+        mock_post.assert_called_once()
+


### PR DESCRIPTION
## Summary
- log authentication flow details in auth views
- add logging to detail views
- verify MFA attempts
- expand gateway view tests
- create real tests for auth views

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68631fe0eb70832a9ef232e8d73740e9